### PR TITLE
Set security bit

### DIFF
--- a/SAMD21_SecurityBit/SAMD21_SecurityBit.ino
+++ b/SAMD21_SecurityBit/SAMD21_SecurityBit.ino
@@ -1,0 +1,43 @@
+void setup()
+{
+  if (!setSecurityBit())
+  {
+    // ERROR: can't set security bit
+
+    // ...
+  }
+
+  // ...
+}
+
+void loop()
+{
+  // ...
+}
+
+bool setSecurityBit()
+{
+  if (!SYSCTRL->BOD33.bit.ENABLE)
+    return false;
+
+  if (NVMCTRL->STATUS.bit.SB)
+    return true;
+
+  while (!NVMCTRL->INTFLAG.bit.READY);
+
+  uint32_t nvmCtrlCtrlBReg = NVMCTRL->CTRLB.reg;
+
+  NVMCTRL->CTRLB.bit.CACHEDIS = 1;
+
+  NVMCTRL->STATUS.reg = NVMCTRL_STATUS_NVME | NVMCTRL_STATUS_LOCKE | NVMCTRL_STATUS_PROGE;
+
+  NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMD_SSB | NVMCTRL_CTRLA_CMDEX_KEY;               
+
+  while (!NVMCTRL->INTFLAG.bit.READY);
+
+  bool returnValue = !(NVMCTRL->STATUS.bit.NVME | NVMCTRL->STATUS.bit.LOCKE | NVMCTRL->STATUS.bit.PROGE);
+
+  NVMCTRL->CTRLB.reg = nvmCtrlCtrlBReg;
+
+  return returnValue;
+}

--- a/SAML21B_SecurityBit/SAML21B_SecurityBit.ino
+++ b/SAML21B_SecurityBit/SAML21B_SecurityBit.ino
@@ -1,0 +1,43 @@
+void setup()
+{
+  if (!setSecurityBit())
+  {
+    // ERROR: can't set security bit
+
+    // ...
+  }
+
+  // ...
+}
+
+void loop()
+{
+  // ...
+}
+
+bool setSecurityBit()
+{
+  if (!SUPC->BOD33.bit.ENABLE)
+    return false;
+
+  if (NVMCTRL->STATUS.bit.SB)
+    return true;
+
+  while (!NVMCTRL->INTFLAG.bit.READY);
+
+  uint32_t nvmCtrlCtrlBReg = NVMCTRL->CTRLB.reg;
+
+  NVMCTRL->CTRLB.bit.CACHEDIS = 1;
+
+  NVMCTRL->STATUS.reg = NVMCTRL_STATUS_NVME | NVMCTRL_STATUS_LOCKE | NVMCTRL_STATUS_PROGE;
+
+  NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMD_SSB | NVMCTRL_CTRLA_CMDEX_KEY;               
+
+  while (!NVMCTRL->INTFLAG.bit.READY);
+
+  bool returnValue = !(NVMCTRL->STATUS.bit.NVME | NVMCTRL->STATUS.bit.LOCKE | NVMCTRL->STATUS.bit.PROGE);
+
+  NVMCTRL->CTRLB.reg = nvmCtrlCtrlBReg;
+
+  return returnValue;
+}


### PR DESCRIPTION
This demo code allows you to set the security bit on the SAMD21 and SAML21 microcontrollers used on Industruino IND.I/O - PROTO and 4-20mA.ker respectively. This enables you to protect the intellectual property of your code by disabling read-out from FLASH by third parties. WARNING: 1. To disable the security bit you need an in-circuit debuger.  2. You will still be able to upload new code via USB with the security bit enabled, only read-out of FLASH is blocked.